### PR TITLE
Revert steamid integration

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -135,8 +135,6 @@ python3-saml
 pyuca                               # For more accurate sorting of translated country names in django-countries
 recommender-xblock                  # https://github.com/edx/RecommenderXBlock
 rest-condition                      # DRF's recommendation for supporting complex permissions
-steamid-social-auth-core==3.4.0     # fork of social-auth-core with steamid-opneidconnect implementation
-python-jose>=3.0.0                  # required for openid connect implementations of python-social-auth
 pysrt                               # Support for SubRip subtitle files, used in the video XModule
 pytz                                # Time zone information database
 PyYAML                              # Used to parse XModule resource templates

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -220,8 +220,6 @@ simplejson==3.17.2        # via -r requirements/edx/base.in, sailthru-client, su
 six==1.15.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, django-wiki, drf-yasg, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, fs, fs-s3fs, help-tokens, html5lib, isodate, libsass, mock, openedx-calc, packaging, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-app-django==4.0.0  # via -r requirements/edx/base.in
-steamid-social-auth-core==3.4.0  # via -r requirements/edx/base.in, social-auth-app-django
-python-jose>=3.0.0        # via steamid-oidc
 sorl-thumbnail==12.6.3    # via -r requirements/edx/base.in, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/base.in
 soupsieve==2.0.1          # via beautifulsoup4


### PR DESCRIPTION
Have to revert the STEAMID integration

   * If not, the docker build fails (patch failed)
   * If commented out patch, the docker image is not working properly

To integrate STEAMID, change in the Dockerfile `Dockerfile_koa` as such: 
```
# Install private requirements: this is useful for installing custom xblocks.
COPY ./requirements/ /openedx/requirements
RUN cd /openedx/requirements/ \
  && touch ./private.txt \
  && pip install -r ./private.txt
```

New
```
# Install private requirements: this is useful for installing custom xblocks.
COPY ./requirements/ /openedx/requirements
RUN cd /openedx/requirements/ \
  && touch ./private.txt \
  && touch ./patch-libs.txt \
  && pip install -r ./private.txt \
  && pip install --upgrade --no-deps --force-reinstall -r ./patch-libs.txt
```